### PR TITLE
use php-amqplib/rabbitmq-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "mtdowling/cron-expression": "1.0.*",
         "mockery/mockery": "~0.9",
         "doctrine/collections": "~1.2",
-        "oldsound/rabbitmq-bundle": "1.6.x-dev"
+        "php-amqplib/rabbitmq-bundle": "~1.8"
     },
     "suggests": {
         "symfony/console": "To use add Jobs via the CLI"


### PR DESCRIPTION
@calumbrodie I guess Mogul will be pegged to a previous version of this bundle? This change is necessary to update apps to the new rabbitmq client packages.