### PR TITLE
fix: Add logging interface to JobPublisher

### DIFF
--- a/Publisher/JobPublisher.php
+++ b/Publisher/JobPublisher.php
@@ -28,12 +28,20 @@ class JobPublisher implements ContainerAwareInterface
     private $jobLogRepository;
 
     /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * @param JobLogRepository $jobLogRepository
+     * @param LoggerInterface $logger
      */
     public function __construct(
-        JobLogRepository $jobLogRepository
+        JobLogRepository $jobLogRepository,
+        LoggerInterface $logger
     ) {
         $this->jobLogRepository = $jobLogRepository;
+        $this->logger = $logger;
     }
 
     /**

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -3,6 +3,7 @@ services:
         class: Markup\JobQueueBundle\Publisher\JobPublisher
         arguments:
             - '@markup_job_queue.repository.job_log'
+            - '@logger'
         calls:
           - [ setContainer,[ '@service_container' ] ]
     markup_job_queue.consumer:


### PR DESCRIPTION
Logger is still called within the JobPublisher class, so needs to be passed in to constructor.