### PR TITLE
chore: specify symfony 2.3 as minimum version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
         }
     ],
     "require": {
-        "symfony/framework-bundle": "~2.1",
-        "symfony/finder": "~2.1",
+        "symfony/framework-bundle": "~2.3",
+        "symfony/finder": "~2.3",
         "symfony/yaml": "~2.3",
         "symfony/console": "~2.3",
         "symfony/process": "~2.3",


### PR DESCRIPTION
Ideally we'd subsequently move on to dropping support for pre 2.7 in a new version, but here's an initial update.