### PR TITLE
fix(log): corrects job logging

### DIFF
--- a/EventSubscriber/AddUuidOptionConsoleCommandEventSubscriber.php
+++ b/EventSubscriber/AddUuidOptionConsoleCommandEventSubscriber.php
@@ -25,7 +25,7 @@ class AddUuidOptionConsoleCommandEventSubscriber implements EventSubscriberInter
         return [
             ConsoleEvents::COMMAND => [
                 ['onConsoleCommand', 100],
-                ['bindInput', -9999999],
+                ['bindInput', -9999998],
             ]
         ];
     }

--- a/EventSubscriber/LogConsoleCommandEventSubscriber.php
+++ b/EventSubscriber/LogConsoleCommandEventSubscriber.php
@@ -39,7 +39,7 @@ class LogConsoleCommandEventSubscriber implements EventSubscriberInterface
     {
         return [
             ConsoleEvents::COMMAND => [
-                ['onConsoleCommand', 10]
+                ['onConsoleCommand', -9999999]
             ]
         ];
     }
@@ -49,6 +49,7 @@ class LogConsoleCommandEventSubscriber implements EventSubscriberInterface
      */
     public function onConsoleCommand(ConsoleCommandEvent $event)
     {
+
         // following jiggerypokery can be removed in symfony 2.8+
         if ($this->isUsingAtLeastSymfony28()) {
             $input = $event->getInput();

--- a/Model/JobLog.php
+++ b/Model/JobLog.php
@@ -196,7 +196,7 @@ class JobLog
      */
     public function getDuration()
     {
-        if (!$this->getCompleted()) {
+        if (!$this->getCompleted() || !$this->getStarted()) {
             return 0;
         }
         $duration = $this->getCompleted() - $this->getStarted();


### PR DESCRIPTION
The 'LogConsoleCommandEventSubscriber' behaviour needs to be triggered AFTER the input is bound. 