### PR TITLE
feat(config): Set no-debug option in CLI consumer config

### DIFF
--- a/Service/SupervisordConfigFileWriter.php
+++ b/Service/SupervisordConfigFileWriter.php
@@ -158,7 +158,7 @@ class SupervisordConfigFileWriter
             }
 
             $consumer = sprintf(
-                '%s -e "%s/console %s --strict-exit-code --env=%s" -c %s -V -i --strict-exit-code',
+                '%s -e "%s/console %s --strict-exit-code --env=%s --no-debug" -c %s -V -i --strict-exit-code',
                 $this->consumerPath,
                 $kernelPath,
                 self::CLI_CONSUMPTION_COMMAND,

--- a/Tests/Service/fixtures/supervisord_config_cli.conf
+++ b/Tests/Service/fixtures/supervisord_config_cli.conf
@@ -1,7 +1,7 @@
 
 
 [program:markup_job_queue_testenv_testqueuea]
-command=/usr/local/bin/rabbitmq-cli-consumer -e "/vagrant/app/console markup:job_queue:consumer --strict-exit-code --env=dev" -c /etc/rabbitmq-cli-consumer/config/testenv_testqueuea_consumer.conf -V -i --strict-exit-code
+command=/usr/local/bin/rabbitmq-cli-consumer -e "/vagrant/app/console markup:job_queue:consumer --strict-exit-code --env=dev --no-debug" -c /etc/rabbitmq-cli-consumer/config/testenv_testqueuea_consumer.conf -V -i --strict-exit-code
 stderr_logfile=/vagrant/app/logs/supervisord.error.log
 stdout_logfile=/vagrant/app/logs/supervisord.out.log
 autostart=false
@@ -10,7 +10,7 @@ stopsignal=QUIT
 
 
 [program:markup_job_queue_testenv_testqueueb]
-command=/usr/local/bin/rabbitmq-cli-consumer -e "/vagrant/app/console markup:job_queue:consumer --strict-exit-code --env=dev" -c /etc/rabbitmq-cli-consumer/config/testenv_testqueueb_consumer.conf -V -i --strict-exit-code
+command=/usr/local/bin/rabbitmq-cli-consumer -e "/vagrant/app/console markup:job_queue:consumer --strict-exit-code --env=dev --no-debug" -c /etc/rabbitmq-cli-consumer/config/testenv_testqueueb_consumer.conf -V -i --strict-exit-code
 stderr_logfile=/vagrant/app/logs/supervisord.error.log
 stdout_logfile=/vagrant/app/logs/supervisord.out.log
 autostart=false


### PR DESCRIPTION
Note: I've not functionally tested this yet. Doesn't seem like there would be any risk though.