### PR TITLE
feat: adds config option to delete job logs immediately when the jobs are complete

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -101,6 +101,9 @@ class Configuration implements ConfigurationInterface
                 ->integerNode('job_logging_ttl')
                     ->defaultValue(1209600)
                 ->end()
+                ->booleanNode('clear_log_for_complete_jobs')
+                    ->defaultFalse()
+                ->end()
             ->end()
         ->end();
 

--- a/DependencyInjection/MarkupJobQueueExtension.php
+++ b/DependencyInjection/MarkupJobQueueExtension.php
@@ -33,7 +33,7 @@ class MarkupJobQueueExtension extends Extension
         $this->addSupervisordConfig($config, $container);
         $this->addCliConsumerConfig($config, $container);
         $this->configureRabbitMqApiClient($config, $container);
-        $this->loadJobLoggingTtl($config, $container);
+        $this->configureJobLogRepository($config, $container);
     }
 
     /**
@@ -124,9 +124,10 @@ class MarkupJobQueueExtension extends Extension
         $queueReader->replaceArgument(1, $rabbitConfig['vhost']);
     }
 
-    private function loadJobLoggingTtl(array $config, ContainerBuilder $container)
+    private function configureJobLogRepository(array $config, ContainerBuilder $container)
     {
-        $definition = $container->getDefinition('markup_job_queue.repository.job_log');
-        $definition->addArgument($config['job_logging_ttl']);
+        $repository = $container->getDefinition('markup_job_queue.repository.job_log');
+        $repository->addMethodCall('setTtl', [$config['job_logging_ttl']]);
+        $repository->addMethodCall('setShouldClearLogForCompleteJob', $config['clear_log_for_complete_jobs']);
     }
 }


### PR DESCRIPTION
fyi @gsdevme

It may not be that useful to store thousands and thousands of records re completed jobs, especially when there is no indication any of the types of jobs may be especially interesting to store. This option allows a user of the library to decide not to store this in Redis, so only errors are stored.