### PR TITLE
feat: add a config option to allow setting location of the symfony console script

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -104,6 +104,10 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('clear_log_for_complete_jobs')
                     ->defaultFalse()
                 ->end()
+                ->booleanNode('use_root_dir_for_symfony_console')
+                    ->defaultFalse()
+                    ->info('Choose whether to use a Symfony app root directory for the location of the Symfony console script. Defaults to app root for Symfony 2, and bin/ for Symfony 3+.')
+                ->end()
             ->end()
         ->end();
 

--- a/Job/ConsoleCommandJob.php
+++ b/Job/ConsoleCommandJob.php
@@ -33,7 +33,12 @@ class ConsoleCommandJob extends Job
         }
 
         // get the absolute path of the console and the environment
-        $command = sprintf('%s %s --env=%s', $this->getConsolePath($container->get('kernel')->getRootdir()), $command, $container->get('kernel')->getEnvironment());
+        $command = sprintf(
+            '%s %s --env=%s',
+            $this->getConsolePath($container->getParameter('markup_job_queue.console_dir')),
+            $command,
+            $container->get('kernel')->getEnvironment()
+        );
 
         $process = new Process($command);
         if (!isset($this->args['timeout'])) {
@@ -49,7 +54,13 @@ class ConsoleCommandJob extends Job
             $process->run();
 
             if (!$process->isSuccessful()) {
-                $message = sprintf('A job `%s` failed with topic `%s` with output:%s and the error output: %s', $command, $this->topic, $process->getOutput(), $process->getErrorOutput());
+                $message = sprintf(
+                    'A job `%s` failed with topic `%s` with output:%s and the error output: %s',
+                    $command,
+                    $this->topic,
+                    $process->getOutput(),
+                    $process->getErrorOutput()
+                );
                 throw new JobFailedException($message, $process->getExitCode());
             }
             return $process->getOutput();


### PR DESCRIPTION
The standard location for the Symfony console script as of Symfony 3 is in `bin/`. This change will follow the default location for the version of Symfony being used, but allow the option to opt in to using the console script in the Symfony 2 compatible location. In Symfony 4, this option will no longer work and the `bin/` location must be used.