### PR TITLE
feat(command): configure recurring jobs to only run in certain envs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: php
 
 matrix:
   include:
-    - php: 5.5
-    - php: 5.6
-    - php: 7.0
     - php: 7.1
       env: deps=low
     - php: 7.1

--- a/Command/AddRecurringConsoleJobToQueueCommand.php
+++ b/Command/AddRecurringConsoleJobToQueueCommand.php
@@ -45,6 +45,20 @@ class AddRecurringConsoleJobToQueueCommand extends ContainerAwareCommand
         $due = $recurringConsoleCommandReader->getDue();
 
         foreach ($due as $configuration) {
+
+            if ($configuration->getEnvs()) {
+                $env = $this->getContainer()->get('kernel')->getEnvironment();
+
+                if (!in_array($env, $configuration->getEnvs())) {
+                    $output->writeln(
+                        sprintf(
+                            '<info>Skipping `%s`, not to run in this env</info>',
+                            $configuration->getCommand()
+                        )
+                    );
+                    continue;
+                }
+            }
             $this->getContainer()->get('jobby')->addCommandJob(
                 $configuration->getCommand(),
                 $configuration->getTopic(),

--- a/Command/ReadRecurringConsoleJobConfigurationCommand.php
+++ b/Command/ReadRecurringConsoleJobConfigurationCommand.php
@@ -47,12 +47,13 @@ class ReadRecurringConsoleJobConfigurationCommand extends ContainerAwareCommand
 
         $output->writeln(sprintf('<info>Treating current time as %s</info>', $time->format('r')));
         $table = (class_exists(Table::class)) ? new Table($output) : $this->getHelperSet()->get('table');
-        $table->setHeaders(['command', 'topic', 'schedule', 'valid command?', 'due?', 'next run?']);
+        $table->setHeaders(['command', 'topic', 'schedule', 'envs', 'valid command?', 'due?', 'next run?']);
         foreach ($recurringConsoleCommandReader->getConfigurations() as $configuration) {
             $row = [];
             $row[] = $configuration->getCommand();
             $row[] = $configuration->getTopic();
             $row[] = $configuration->getSchedule();
+            $row[] = $configuration->getEnvs() ? implode(',', $configuration->getEnvs()) : 'all';
             $row[] = $this->isCommandValid($configuration->getCommand()) ? '✓' : '✗';
             $row[] = $configuration->isDue($time) ? '✓' : '✗';
             if ($configuration->nextRun()) {

--- a/Model/RecurringConsoleCommandConfiguration.php
+++ b/Model/RecurringConsoleCommandConfiguration.php
@@ -26,29 +26,36 @@ class RecurringConsoleCommandConfiguration
     private $topic;
 
     /**
-     * @var string
+     * @var int
      */
     private $timeout;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $description;
+
+    /**
+     * @var array|null
+     */
+    private $envs;
 
     /**
      * @param string  $command
      * @param string  $topic
      * @param string  $schedule
-     * @param string  $description
-     * @param integer $timeout
+     * @param string|null  $description
+     * @param integer|null $timeout
+     * @param array|null $envs
      */
-    public function __construct($command, $topic, $schedule, $description = null, $timeout = 60)
+    public function __construct($command, $topic, $schedule, $description = null, $timeout = 60, $envs = null)
     {
         $this->command = $command;
         $this->schedule = $schedule;
         $this->topic = str_replace('-', '_', $topic);
         $this->timeout = $timeout;
         $this->description = $description;
+        $this->envs = $envs;
     }
 
     /**
@@ -183,5 +190,13 @@ class RecurringConsoleCommandConfiguration
     public function getDescription()
     {
         return $this->description;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getEnvs(): ?array
+    {
+        return $this->envs;
     }
 }

--- a/Service/RecurringConsoleCommandReader.php
+++ b/Service/RecurringConsoleCommandReader.php
@@ -127,12 +127,17 @@ class RecurringConsoleCommandReader
                 throw new InvalidConfigurationException('Every job schedule should have a `command`, `topic` and `schedule` component'.json_encode($config));
             }
 
+            if (isset($group['envs']) && !is_array($group['envs'])) {
+                throw new InvalidConfigurationException('`envs` config key must be an array or null');
+            }
+
             $recurringConsoleCommandConfiguration = new RecurringConsoleCommandConfiguration(
                 $group['command'],
                 $group['topic'],
                 $group['schedule'],
                 isset($group['description']) ? $group['description'] : null,
-                isset($group['timeout']) ? $group['timeout'] : null
+                isset($group['timeout']) ? $group['timeout'] : null,
+                isset($group['envs']) ? $group['envs'] : null
             );
 
             $configurations->add($recurringConsoleCommandConfiguration);

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
         "doctrine/orm": "~2.3",
         "doctrine/collections": "^1.2",
         "php-amqplib/rabbitmq-bundle": "^1.8",
-        "markup/rabbitmq-management-api": "^2",
         "snc/redis-bundle": "~1.1.2|^2",
         "markup/rabbitmq-management-api": ">=2.1.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/console": "^2.3|^3",
         "symfony/process": "^2.3|^3",
         "twig/twig": "^1.12|^2",
-        "php": ">=5.5.0",
+        "php": ">=7.1.0",
         "mtdowling/cron-expression": "1.0.*",
         "doctrine/orm": "~2.3",
         "doctrine/collections": "^1.2",


### PR DESCRIPTION
Optionally add a 'envs' node to your recurring job config:

thus: 

```
# adds a work job every minute
- command: markup:job_queue:run:test work
  schedule: '* * * * *'
  topic: system-quick
  timeout: 3600
  envs: ['dev']
```