### PR TITLE
chore: drop symfony v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,12 @@
         }
     ],
     "require": {
-        "symfony/framework-bundle": "^2.3|^3",
-        "symfony/finder": "^2.3|^3",
-        "symfony/yaml": "^2.3|^3",
-        "symfony/console": "^2.3|^3",
-        "symfony/process": "^2.3|^3",
-        "twig/twig": "^1.12|^2",
+        "symfony/framework-bundle": "^3",
+        "symfony/finder": "^3",
+        "symfony/yaml": "^3",
+        "symfony/console": "^3",
+        "symfony/process": "^3",
+        "twig/twig": "^2",
         "php": ">=7.1.0",
         "mtdowling/cron-expression": "1.0.*",
         "doctrine/orm": "~2.3",
@@ -32,7 +32,7 @@
     "require-dev": {
         "phpunit/phpunit": "~4.5",
         "mockery/mockery": "~0.9",
-        "symfony/form": "~2.3|^3",
+        "symfony/form": "^3",
         "predis/predis": "^1.0"
     },
     "suggest": {


### PR DESCRIPTION
This drops Symfony v2 from the dependencies.