### PR TITLE
refactor JobLog repository to doctrine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   - if [ "$deps" = "low" ]; then composer --prefer-lowest -n --prefer-stable --prefer-dist update; fi;
 
 
-script: bin/phpunit
+script: bin/phpunit && bin/phpstan analyse -l 1 ./
 
 notifications:
   email: "calum@usemarkup.com"

--- a/Command/AddCommandJobToQueueCommand.php
+++ b/Command/AddCommandJobToQueueCommand.php
@@ -2,7 +2,8 @@
 
 namespace Markup\JobQueueBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Markup\JobQueueBundle\Service\JobManager;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -11,8 +12,19 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * This command adds another command to the job queue
  */
-class AddCommandJobToQueueCommand extends ContainerAwareCommand
+class AddCommandJobToQueueCommand extends Command
 {
+    /**
+     * @var JobManager
+     */
+    private $jobby;
+
+    public function __construct(JobManager $jobby)
+    {
+        parent::__construct();
+        $this->jobby = $jobby;
+    }
+
     /**
      * @see Command
      */
@@ -54,7 +66,7 @@ class AddCommandJobToQueueCommand extends ContainerAwareCommand
         $timeout = $input->getOption('timeout');
         $idleTimeout = $input->getOption('idle_timeout');
 
-        $this->getContainer()->get('jobby')->addCommandJob($command, $topic, $timeout, $idleTimeout);
+        $this->jobby->addCommandJob($command, $topic, $timeout, $idleTimeout);
 
         $output->writeln('<info>Added command to job queue</info>');
     }

--- a/Command/AddCommandJobToQueueCommand.php
+++ b/Command/AddCommandJobToQueueCommand.php
@@ -61,10 +61,10 @@ class AddCommandJobToQueueCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $command = $input->getArgument('cmd');
-        $topic = $input->getArgument('topic');
-        $timeout = $input->getOption('timeout');
-        $idleTimeout = $input->getOption('idle_timeout');
+        $command = strval($input->getArgument('cmd'));
+        $topic = strval($input->getArgument('topic'));
+        $timeout = intval($input->getOption('timeout'));
+        $idleTimeout = intval($input->getOption('idle_timeout'));
 
         $this->jobby->addCommandJob($command, $topic, $timeout, $idleTimeout);
 

--- a/Command/AddRecurringConsoleJobToQueueCommand.php
+++ b/Command/AddRecurringConsoleJobToQueueCommand.php
@@ -81,6 +81,6 @@ class AddRecurringConsoleJobToQueueCommand extends ContainerAwareCommand
 
     private function maintainJobLogs()
     {
-        $this->getContainer()->get('markup_job_queue.repository.job_log')->removeExpiredJobsFromSecondaryIndexes();
+        $this->getContainer()->get('markup_job_queue.repository.job_log')->removeExpiredJobs();
     }
 }

--- a/Command/AddRecurringConsoleJobToQueueCommand.php
+++ b/Command/AddRecurringConsoleJobToQueueCommand.php
@@ -2,6 +2,7 @@
 
 namespace Markup\JobQueueBundle\Command;
 
+use Markup\JobQueueBundle\Model\RecurringConsoleCommandConfiguration;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -44,6 +45,9 @@ class AddRecurringConsoleJobToQueueCommand extends ContainerAwareCommand
         $due = $recurringConsoleCommandReader->getDue();
 
         foreach ($due as $configuration) {
+            if (!$configuration instanceof RecurringConsoleCommandConfiguration) {
+                throw new \Exception('Invalid configuration');
+            }
 
             if ($configuration->getEnvs()) {
                 $env = $this->getContainer()->get('kernel')->getEnvironment();

--- a/Command/CheckRecurringJobConfigurationCommand.php
+++ b/Command/CheckRecurringJobConfigurationCommand.php
@@ -24,6 +24,8 @@ class CheckRecurringJobConfigurationCommand extends ContainerAwareCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $reader = $this->getContainer()->get('markup_job_queue.reader.recurring_console_command');
+
+        $message = '';
         /**
          * @var RecurringConsoleCommandReader $reader
          */
@@ -32,13 +34,16 @@ class CheckRecurringJobConfigurationCommand extends ContainerAwareCommand
             $isGood = true;
         } catch (InvalidConfigurationException $e) {
             $isGood = false;
+
+            $message = $e->getMessage();
         }
+
         if ($isGood) {
             $output->writeln('<info>Recurring jobs config is good.</info>');
 
             return 0;
         } else {
-            $output->writeln(sprintf('<error>Recurring jobs config is invalid. Message: %s</error>', $e->getMessage()));
+            $output->writeln(sprintf('<error>Recurring jobs config is invalid. Message: %s</error>', $message));
 
             return 1;
         }

--- a/Consumer/JobConsumer.php
+++ b/Consumer/JobConsumer.php
@@ -4,8 +4,8 @@ namespace Markup\JobQueueBundle\Consumer;
 
 use Markup\JobQueueBundle\Exception\JobFailedException;
 use Markup\JobQueueBundle\Exception\JobMissingClassException;
-use Markup\JobQueueBundle\Job\ConsoleCommandJob;
 use Markup\JobQueueBundle\Model\Job;
+use Markup\JobQueueBundle\Job\ConsoleCommandJob;
 use OldSound\RabbitMqBundle\RabbitMq\ConsumerInterface;
 use PhpAmqpLib\Message\AMQPMessage;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
@@ -56,7 +56,7 @@ class JobConsumer implements ConsumerInterface, ContainerAwareInterface
             }
 
             $exitCode = null;
-            $output = $e->getMessage();
+            $output = sprintf('%s - %s', $e->getMessage(), $e->getTraceAsString());
             if ($e instanceof JobFailedException) {
                 $exitCode = intval($e->getExitCode());
             }

--- a/Entity/ScheduledJob.php
+++ b/Entity/ScheduledJob.php
@@ -41,9 +41,9 @@ class ScheduledJob
     private $updated;
 
     /**
-     * @param $job
-     * @param $scheduledTime
-     * @param $topic
+     * @param mixed $job
+     * @param mixed $scheduledTime
+     * @param mixed $topic
      */
     function __construct($job, $scheduledTime, $topic)
     {

--- a/EventSubscriber/AddUuidOptionConsoleCommandEventSubscriber.php
+++ b/EventSubscriber/AddUuidOptionConsoleCommandEventSubscriber.php
@@ -40,12 +40,24 @@ class AddUuidOptionConsoleCommandEventSubscriber implements EventSubscriberInter
             null
         );
 
-        $definition = $event->getCommand()->getDefinition();
+        $command = $event->getCommand();
+
+        if (!$command) {
+            return;
+        }
+
+        $definition = $command->getDefinition();
         $definition->addOption($inputOption);
     }
 
     public function bindInput(ConsoleCommandEvent $event)
     {
-        $event->getInput()->bind($event->getCommand()->getDefinition());
+        $command = $event->getCommand();
+
+        if (!$command) {
+            return;
+        }
+
+        $event->getInput()->bind($command->getDefinition());
     }
 }

--- a/EventSubscriber/LogConsoleCommandEventSubscriber.php
+++ b/EventSubscriber/LogConsoleCommandEventSubscriber.php
@@ -2,12 +2,10 @@
 
 namespace Markup\JobQueueBundle\EventSubscriber;
 
-use Markup\JobQueueBundle\Exception\UnknownJobLogException;
-use Markup\JobQueueBundle\Model\JobLog;
+use Markup\JobQueueBundle\Entity\JobLog;
 use Markup\JobQueueBundle\Repository\JobLogRepository;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
-use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -59,16 +57,16 @@ class LogConsoleCommandEventSubscriber implements EventSubscriberInterface
         }
 
         // lookup job log repository for log and create one if it doesn't exist
-        try { 
-            $log = $this->jobLogRepository->getJobLog($uuid);
-        } catch (UnknownJobLogException $e) {
+
+        $log = $this->jobLogRepository->findJobLog($uuid);
+        if (!$log) {
             $commandString = $input->__toString();
             $log = $this->jobLogRepository->createAndSaveJobLog($commandString, $uuid);
         }
         
         // update job log to change status to running
         $log->setStatus(JobLog::STATUS_RUNNING);
-        $log->setStarted((new \DateTime('now'))->format('U'));
+        $log->setStarted(new \DateTime());
         $this->jobLogRepository->save($log);
     }
 }

--- a/Exception/UnknownJobLogException.php
+++ b/Exception/UnknownJobLogException.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Markup\JobQueueBundle\Exception;
-
-class UnknownJobLogException extends \Exception
-{
-
-}

--- a/Form/Data/SearchJobLogs.php
+++ b/Form/Data/SearchJobLogs.php
@@ -2,19 +2,12 @@
 
 namespace Markup\JobQueueBundle\Form\Data;
 
-use Pagerfanta\Adapter\FixedAdapter;
-
 class SearchJobLogs
 {
     /**
      * @var string
      */
     private $id;
-
-    /**
-     * @var string
-     */
-    private $commandConfigurationId;
 
     /**
      * @var string
@@ -46,126 +39,54 @@ class SearchJobLogs
         $this->page = 1;
     }
 
-    /**
-     * @return string
-     */
-    public function getId()
+    public function getId(): ?string
     {
         return $this->id;
     }
 
-    /**
-     * @param string $id
-     */
-    public function setId($id)
+    public function setId(string $id)
     {
         $this->id = $id;
     }
 
-    /**
-     * @return string
-     */
-    public function getCommandConfigurationId()
-    {
-        return $this->commandConfigurationId;
-    }
-
-    /**
-     * @param string $commandConfigurationId
-     */
-    public function setCommandConfigurationId($commandConfigurationId)
-    {
-        $this->commandConfigurationId = $commandConfigurationId;
-    }
-
-    /**
-     * @return string
-     */
-    public function getCommand()
+    public function getCommand(): ?string
     {
         return $this->command;
     }
 
-    /**
-     * @param string $command
-     */
-    public function setCommand($command)
+    public function setCommand(string $command)
     {
         $this->command = $command;
     }
 
-    /**
-     * @return \DateTime
-     */
-    public function getBefore()
+    public function getBefore(): ?\DateTime
     {
         return $this->before;
     }
 
-    /**
-     * @param \DateTime $before
-     */
-    public function setBefore($before)
+    public function setBefore(?\DateTime $before = null)
     {
         $this->before = $before;
     }
-    /**
-     * @return \DateTime
-     */
-    public function getSince()
+
+    public function getSince(): ?\DateTime
     {
         return $this->since;
     }
 
-    /**
-     * @param \DateTime $since
-     */
-    public function setSince($since)
+    public function setSince(?\DateTime $since = null)
     {
         $this->since = $since;
     }
 
-    /**
-     * @return string
-     */
-    public function getStatus()
+    public function getStatus(): ?string
     {
         return $this->status;
     }
 
-    /**
-     * @param string $status
-     */
-    public function setStatus($status)
+    public function setStatus(string $status)
     {
         $this->status = $status;
-    }
-
-    /**
-     * @return int
-     */
-    public function getPage()
-    {
-        return $this->page;
-    }
-
-    /**
-     * @param int $page
-     */
-    public function setPage($page)
-    {
-        if (!$page) {
-            return;
-        }
-        $this->page = $page;
-    }
-
-    /**
-     * @return int Gets a zero indexed version of the page for use in a query
-     */
-    public function getPageOffset()
-    {
-        return max(0, $this->getPage() - 1);
     }
 
     /**
@@ -203,6 +124,16 @@ class SearchJobLogs
         return false;
     }
 
+    public function setPage(int $page)
+    {
+        $this->page = $page;
+    }
+
+    public function getPage(): int
+    {
+        return $this->page;
+    }
+
     public function toArray()
     {
         return [
@@ -210,7 +141,7 @@ class SearchJobLogs
             'since' => $this->getSince(),
             'before' => $this->getBefore(),
             'status' => $this->getStatus(),
-            'command_configuration_id' => $this->getCommandConfigurationId()
+            'command' => $this->getCommand()
         ];
     }
 

--- a/Form/Handler/SearchJobLogs.php
+++ b/Form/Handler/SearchJobLogs.php
@@ -3,7 +3,6 @@
 namespace Markup\JobQueueBundle\Form\Handler;
 
 use Markup\JobQueueBundle\Repository\JobLogRepository;
-use Pagerfanta\Adapter\FixedAdapter;
 use Pagerfanta\Pagerfanta;
 use Markup\JobQueueBundle\Form\Data\SearchJobLogs as SearchJobLogsData;
 
@@ -12,8 +11,6 @@ use Markup\JobQueueBundle\Form\Data\SearchJobLogs as SearchJobLogsData;
  */
 class SearchJobLogs
 {
-    const PAGINATION_LIMIT = 10;
-
     /**
      * @var JobLogRepository
      */
@@ -28,20 +25,14 @@ class SearchJobLogs
     }
 
     /**
-     * @param SearchJobLogs $data
-     * @returns PagerFanta
+     * @param SearchJobLogsData $options
+     *
+     * @param int $page
+     *
+     * @return Pagerfanta
      */
-    public function handle(SearchJobLogsData $options)
+    public function handle(SearchJobLogsData $options, int $page = 1)
     {
-        $count = $this->jobLogRepository->getJobLogs($options, self::PAGINATION_LIMIT, $countOnly = true);
-        $results = $this->jobLogRepository->getJobLogs($options, self::PAGINATION_LIMIT);
-
-        $adapter = new FixedAdapter($count, $results);
-        $logs = new Pagerfanta($adapter);
-
-        $logs->setCurrentPage($options->getPage());
-        $logs->setMaxPerPage(self::PAGINATION_LIMIT);
-
-        return $logs;
+        return $this->jobLogRepository->getJobLogs($options, 10, $page);
     }
 }

--- a/Form/Type/SearchJobLogs.php
+++ b/Form/Type/SearchJobLogs.php
@@ -3,9 +3,12 @@
 namespace Markup\JobQueueBundle\Form\Type;
 
 use Markup\JobQueueBundle\Form\Data\SearchJobLogs as SearchJobLogsData;
-use Markup\JobQueueBundle\Model\JobLog;
-use Markup\JobQueueBundle\Util\LegacyFormHelper;
+use Markup\JobQueueBundle\Entity\JobLog;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -15,14 +18,21 @@ class SearchJobLogs extends AbstractType
     {
         $builder->add(
             'id',
-            LegacyFormHelper::getType('Symfony\Component\Form\Extension\Core\Type\TextType'),
+            TextType::class,
             [
                 'required' => false,
                 'label'    => 'Uuid'
             ]
         )->add(
+            'command',
+            TextType::class,
+            [
+                'required' => false,
+                'label'    => 'Command'
+            ]
+        )->add(
             'since',
-            LegacyFormHelper::getType('Symfony\Component\Form\Extension\Core\Type\DateTimeType'),
+            DateTimeType::class,
             [
                 'widget'   => 'single_text',
                 'attr'     => ['data-dtime-format' => "YYYY-MM-DDTHH:mm:ssZ"],
@@ -32,7 +42,7 @@ class SearchJobLogs extends AbstractType
             ]
         )->add(
             'before',
-            LegacyFormHelper::getType('Symfony\Component\Form\Extension\Core\Type\DateTimeType'),
+            DateTimeType::class,
             [
                 'widget'   => 'single_text',
                 'attr'     => ['data-dtime-format' => "YYYY-MM-DDTHH:mm:ssZ"],
@@ -42,7 +52,7 @@ class SearchJobLogs extends AbstractType
             ]
         )->add(
             'status',
-            LegacyFormHelper::getType('Symfony\Component\Form\Extension\Core\Type\ChoiceType'),
+            ChoiceType::class,
             [
                 'required' => false,
                 'multiple' => false,
@@ -56,20 +66,8 @@ class SearchJobLogs extends AbstractType
                 'choices_as_values' => true,
             ]
         )->add(
-            'command_configuration_id',
-            LegacyFormHelper::getType('Symfony\Component\Form\Extension\Core\Type\HiddenType'),
-            [
-                'required' => false,
-            ]
-        )->add(
-            'page',
-            LegacyFormHelper::getType('Symfony\Component\Form\Extension\Core\Type\HiddenType'),
-            [
-                'required' => false,
-            ]
-        )->add(
             'search',
-            LegacyFormHelper::getType('Symfony\Component\Form\Extension\Core\Type\SubmitType'),
+            SubmitType::class,
             ['attr' => ['class' => 'btn-info'], 'icon' => 'search', 'label' => 'Search']
         );
     }

--- a/Job/BadJob.php
+++ b/Job/BadJob.php
@@ -14,8 +14,10 @@ class BadJob extends Job
     /**
      * {@inheritdoc}
      */
-    public function run(ContainerInterface $container)
+    public function run(ContainerInterface $container): string
     {
         callToUndefinedFunction();
+
+        return '';
     }
 }

--- a/Job/BadJob.php
+++ b/Job/BadJob.php
@@ -16,8 +16,6 @@ class BadJob extends Job
      */
     public function run(ContainerInterface $container): string
     {
-        callToUndefinedFunction();
-
-        return '';
+        throw new \Exception('Error');
     }
 }

--- a/Job/ConsoleCommandJob.php
+++ b/Job/ConsoleCommandJob.php
@@ -46,7 +46,7 @@ class ConsoleCommandJob extends Job
         }
         $process->setTimeout((int) $this->args['timeout']);
         if (!isset($this->args['idleTimeout'])) {
-            $this->idleTimeout = $this->args['idleTimeout'];
+            $this->args['idleTimeout'] = $process->getIdleTimeout();
         }
         $process->setIdleTimeout((int) $this->args['idleTimeout']);
 

--- a/Job/ConsoleCommandJob.php
+++ b/Job/ConsoleCommandJob.php
@@ -20,7 +20,7 @@ class ConsoleCommandJob extends Job
     /**
      * {inheritdoc}
      */
-    public function run(ContainerInterface $container)
+    public function run(ContainerInterface $container): string
     {
         ini_set('max_execution_time', 7200);
         $command = $this->args['command'];
@@ -63,7 +63,7 @@ class ConsoleCommandJob extends Job
                 );
                 throw new JobFailedException($message, $process->getExitCode());
             }
-            return $process->getOutput();
+            return strval($process->getOutput());
          } catch (ProcessTimedOutException $e) {
             if ($e->isGeneralTimeout()) {
                 throw new JobFailedException(sprintf('Timeout: %s', $e->getMessage()), $process->getExitCode(), 0, $e);

--- a/Job/ExceptionJob.php
+++ b/Job/ExceptionJob.php
@@ -11,7 +11,7 @@ class ExceptionJob extends Job
     /**
      * {@inheritdoc}
      */
-    public function run(ContainerInterface $container)
+    public function run(ContainerInterface $container): string
     {
         throw new JobFailedException('Test job throws an exception');
     }

--- a/Job/MonologErrorJob.php
+++ b/Job/MonologErrorJob.php
@@ -13,9 +13,11 @@ class MonologErrorJob extends Job
     /**
      * {@inheritdoc}
      */
-    public function run(ContainerInterface $container)
+    public function run(ContainerInterface $container): string
     {
         $logger = $container->get('logger');
         $logger->error('Test job produced an error');
+
+        return 'Test job produced an error';
     }
 }

--- a/Job/SleepJob.php
+++ b/Job/SleepJob.php
@@ -28,9 +28,11 @@ class SleepJob extends Job
     /**
      * {@inheritdoc}
      */
-    public function run(ContainerInterface $container)
+    public function run(ContainerInterface $container): string
     {
         $process = new Process(sprintf('sleep %s', $this->args['time']));
         $process->run();
+
+        return '';
     }
 }

--- a/Job/WorkJob.php
+++ b/Job/WorkJob.php
@@ -30,7 +30,7 @@ class WorkJob extends Job
     /**
      * {@inheritdoc}
      */
-    public function run(ContainerInterface $container)
+    public function run(ContainerInterface $container): string
     {
         $garbage = '';
         $completed = 0;
@@ -38,5 +38,7 @@ class WorkJob extends Job
             $garbage .= password_hash(openssl_random_pseudo_bytes($this->args['complexity']), PASSWORD_BCRYPT);
             $completed++;
         }
+
+        return '';
     }
 }

--- a/MarkupJobQueueBundle.php
+++ b/MarkupJobQueueBundle.php
@@ -4,16 +4,11 @@ namespace Markup\JobQueueBundle;
 
 use Symfony\Component\Console\Application;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
-use Symfony\Component\HttpKernel\Kernel;
 
 class MarkupJobQueueBundle extends Bundle
 {
     public function registerCommands(Application $application)
     {
-        if (version_compare(Kernel::VERSION, '2.7', '>=')) {
-            return;
-        }
-        parent::registerCommands($application);
+        // Do nothing
     }
-
 }

--- a/Model/Job.php
+++ b/Model/Job.php
@@ -45,9 +45,11 @@ abstract class Job
     }
 
     /**
-     * @param ContainerInterface|null $container
+     * @param ContainerInterface $container
+     *
+     * @return string - output of command
      */
-    abstract public function run(ContainerInterface $container);
+    abstract public function run(ContainerInterface $container): string;
 
     /**
      * To be run after job constructed to check arguments are correct

--- a/Model/JobLogCollection.php
+++ b/Model/JobLogCollection.php
@@ -2,6 +2,7 @@
 
 namespace Markup\JobQueueBundle\Model;
 
+use Markup\JobQueueBundle\Entity\JobLog;
 use Doctrine\Common\Collections\ArrayCollection;
 
 /**

--- a/Reader/QueueReader.php
+++ b/Reader/QueueReader.php
@@ -21,13 +21,9 @@ class QueueReader
      */
     private $vhost;
 
-    /**
-     * @param ApiFactory $apiFactory
-     * @param            $vhost
-     */
     public function __construct(
         ApiFactory $apiFactory,
-        $vhost
+        string $vhost
     ) {
         $this->api = $apiFactory;
         $this->vhost = $vhost;

--- a/Reader/RecurringConsoleCommandConfigurationJobLogReader.php
+++ b/Reader/RecurringConsoleCommandConfigurationJobLogReader.php
@@ -49,7 +49,7 @@ class RecurringConsoleCommandConfigurationJobLogReader
         foreach ($configurations as $configuration) {
             $searchData = new SearchJobLogs();
             $searchData->setCommand($configuration->getCommand());
-            $jobLogs = $this->jobLogRepository->getJobLogs($searchData, $maxQuantity);
+            $jobLogs = $this->jobLogRepository->getJobLogCollection($searchData, $maxQuantity);
 
             $collection[$configuration->getUuid()] = $jobLogs;
         }

--- a/Repository/CronHealthRepository.php
+++ b/Repository/CronHealthRepository.php
@@ -13,6 +13,11 @@ class CronHealthRepository
     const REDIS_KEY = 'markup_job_queue:recurring_cron_health';
 
     /**
+     * @var Predis
+     */
+    private $predis;
+
+    /**
      * JobLogRepository constructor.
      * @param Predis $predis
      */

--- a/Repository/JobLogRepository.php
+++ b/Repository/JobLogRepository.php
@@ -2,37 +2,23 @@
 
 namespace Markup\JobQueueBundle\Repository;
 
-use Markup\JobQueueBundle\Exception\UnknownJobLogException;
-use Markup\JobQueueBundle\Model\JobLog;
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\Query;
+use Markup\JobQueueBundle\Entity\JobLog;
 use Markup\JobQueueBundle\Model\JobLogCollection;
 use Markup\JobQueueBundle\Form\Data\SearchJobLogs as SearchJobLogsData;
-use Markup\JobQueueBundle\Service\RecurringConsoleCommandReader;
-use Predis\Client as Predis;
+use Pagerfanta\Adapter\DoctrineORMAdapter;
+use Pagerfanta\Pagerfanta;
 
 /**
  * Get and Set JobLogs (from redis)
  */
 class JobLogRepository
 {
-    const REDIS_NAMESPACE = 'markup_job_queue';
-
     // 2 weeks
     const DEFAULT_LOG_TTL = '1209600';
-
-    /**
-     * @var Predis
-     */
-    private $predis;
-
-    /**
-     * @var Predis
-     */
-    private $tempKey;
-
-    /**
-     * @var RecurringConsoleCommandReader
-     */
-    private $recurringConsoleCommandReader;
 
     /**
      * @var int
@@ -45,388 +31,217 @@ class JobLogRepository
     private $shouldClearLogForCompleteJob;
 
     /**
-     * @param Predis $predis
-     * @param RecurringConsoleCommandReader $recurringConsoleCommandReader
+     * @var ManagerRegistry
+     */
+    private $doctrine;
+
+    /**
      * @param int|null $ttl
      */
     public function __construct(
-        Predis $predis,
-        RecurringConsoleCommandReader $recurringConsoleCommandReader,
+        ManagerRegistry $doctrine,
         $ttl = null
     ) {
-        $this->predis = $predis;
-        $this->recurringConsoleCommandReader = $recurringConsoleCommandReader;
-        $this->tempKey = null;
         $this->ttl = $ttl ?: self::DEFAULT_LOG_TTL;
         $this->shouldClearLogForCompleteJob = false;
+        $this->doctrine = $doctrine;
     }
 
-    /**
-     * @param string $command
-     * @param string|null $uuid
-     * @param string|null $topic
-     * @return JobLog
-     */
-    public function createAndSaveJobLog($command, $uuid = null, $topic = null)
+    public function createAndSaveJobLog(string $command, ?string $uuid = null, ?string $topic = null): JobLog
     {
         $log = new JobLog($command, $uuid, $topic);
-        $this->save($log, $initial = true);
+        $this->save($log);
         return $log;
     }
 
-    /**
-     *
-     * @param JobLog $jobLog
-     * @param boolean $false If set to true will add the job to secondary indexes
-     */
-    public function save(JobLog $jobLog, $initial = false)
+    public function save(JobLog $jobLog): void
     {
-        $compressed = $jobLog->toCompressedArray();
-
-        // this key identifies the job in all indexes
-        $hashKey = $this->getJobLogKey($jobLog->getUuid());
-
-        if ($this->shouldClearLogForCompleteJob && $jobLog->getStatus() === JobLog::STATUS_COMPLETE) {
-            $this->predis->del($hashKey);
-            return;
-        }
-
-        // add/update canonical record
-        $this->predis->hmset($hashKey, $compressed);
-        $this->predis->expire($hashKey, $this->ttl);
-
-        // update the 'status' index
-        $this->addJobToStatusIndex($hashKey, $jobLog->getStatus());
-
-        if(!$initial) {
-            return;
-        }
-
-        // add to 'added' range index
-        $this->addJobToTimeAddedIndex($hashKey, $compressed['added']);
-
-        // and also to command index which stores every log for a given command
-        $this->addJobToCommandKeyIndex($hashKey, $jobLog->getCommand());
-    }
-
-    /**
-     * @param $hashKey
-     * @param $added
-     */
-    private function addJobToTimeAddedIndex($hashKey, $added)
-    {
-        $indexName = $this->getJobAddedKey();
-        $data = [$hashKey => $added];
-        $this->predis->zadd($indexName, $data);
-    }
-
-    /**
-     * @param $hashKey
-     */
-    private function removeJobFromTimeAddedIndex($hashKey)
-    {
-        $indexName = $this->getJobAddedKey();
-        $this->predis->zrem($indexName, $hashKey);
-    }
-
-    /**
-     * @param $hashKey
-     * @param $command
-     */
-    private function addJobToCommandKeyIndex($hashKey, $command)
-    {
-        // Only add to the command key index if the command is within the recurring jobs library
-        // it only needs to be looked up for recurring console commands, so no point in creating sets for all other commands
-        if(!in_array($command, $this->recurringConsoleCommandReader->getConfigurationCommands())) {
-            return;
-        }
-        $indexName = $this->getCommandKey($command);
-        $this->predis->sadd($indexName, $hashKey);
-    }
-
-    /**
-     * @param $hashKey
-     */
-    private function removeJobFromCommandKeyIndexes($hashKey)
-    {
-        // iterates known commands from recurring job config in order to get list of known commands for which to expire
-        foreach($this->recurringConsoleCommandReader->getConfigurationCommands() as $command) {
-            $indexName = $this->getCommandKey($command);
-            $this->predis->srem($indexName, $hashKey);
-        }
-    }
-
-    /**
-     * Adds the job to one status index and removes it from all others
-     * @param $hashKey
-     * @param $jobStatus
-     */
-    private function addJobToStatusIndex($hashKey, $jobStatus)
-    {
-        foreach([JobLog::STATUS_ADDED, JobLog::STATUS_RUNNING, JobLog::STATUS_FAILED, JobLog::STATUS_COMPLETE] as $status) {
-            if ($status === $jobStatus) {
-                $this->predis->sadd($this->getStatusKey($status), $hashKey);
-            } else {
-                $this->predis->srem($this->getStatusKey($status), $hashKey);
+        $existingJobLog = $this->findJobLog($jobLog->getUuid());
+        if ($existingJobLog) {
+            if ($this->shouldClearLogForCompleteJob) {
+                if ($jobLog->getStatus() === JobLog::STATUS_COMPLETE) {
+                    $this->deleteJob($existingJobLog);
+                }
+                return;
             }
+
+            // update status of existing job
+            $existingJobLog->setStatus($jobLog->getStatus());
+
+            $this->update($existingJobLog);
+            return;
         }
+
+        // if no existing job, store new job
+
+        $this->add($jobLog);
     }
 
-    /**
-     * @param $hashKey
-     */
-    private function removeJobFromStatusIndexes($hashKey)
+    public function saveFailure(string $uuid, string $output = '', ?int $exitCode = null): void
     {
-        foreach([JobLog::STATUS_ADDED, JobLog::STATUS_RUNNING, JobLog::STATUS_FAILED, JobLog::STATUS_COMPLETE] as $status) {
-            $this->predis->srem($this->getStatusKey($status), $hashKey);
+        $log = $this->findJobLog($uuid);
+        if (!$log) {
+            return ;
         }
+        $log->setStatus(JobLog::STATUS_FAILED);
+        if (!$log->getCompleted()) {
+            $log->setCompleted(new \DateTime());
+        }
+        $log->setOutput($output);
+        if ($exitCode) {
+            $log->setExitCode($exitCode);
+        }
+        $this->save($log);
+    }
+
+    public function saveOutput(string $uuid, string $output = ''): void
+    {
+          $log = $this->findJobLog($uuid);
+          if (!$log) {
+              return;
+          }
+          $log->setOutput($output);
+          $this->save($log);
+    }
+
+    public function getJobLogs(SearchJobLogsData $data, $maxPerPage = 10, $currentPage = 1): Pagerfanta
+    {
+        $query = $this->getJobLogQuery($data);
+
+        $jobLogs = new Pagerfanta(
+            new DoctrineORMAdapter($query, true, false)
+        );
+
+        $jobLogs->setMaxPerPage($maxPerPage);
+        $jobLogs->setCurrentPage($currentPage);
+
+        return $jobLogs;
+    }
+
+    public function getJobLogCollection(SearchJobLogsData $data, $limit = 10): JobLogCollection
+    {
+        $query = $this->getJobLogQuery($data, $limit);
+
+        $collection = new JobLogCollection();
+
+        foreach ($query->getResult() as $row) {
+            $collection->add($row);
+        }
+
+        return $collection;
+    }
+
+    private function getJobLogQuery(SearchJobLogsData $data, ?int $limit = null): Query
+    {
+        $qb = $this->getEntityRepository()->createQueryBuilder('j');
+        if ($data->getId()) {
+            $qb->where($qb->expr()->like('j.uuid', ':uuid'))
+                ->setParameter(':uuid', $data->getId());
+        }
+
+        if ($data->getSince()) {
+            $qb->andWhere($qb->expr()->gte('j.added', ':after'))
+                ->setParameter(':after', $data->getSince());
+        }
+
+        if ($data->getBefore()) {
+            $qb->andWhere($qb->expr()->lte('j.added', ':before'))
+                ->setParameter(':before', $data->getBefore());
+        }
+
+        if ($data->getStatus()) {
+            $qb->andWhere($qb->expr()->eq('j.status', ':status'))
+                ->setParameter(':status', $data->getStatus());
+        }
+
+        if ($data->getCommand()) {
+            $qb->andWhere($qb->expr()->like('j.command', ':command'))
+                ->setParameter(':command', $data->getCommand().'%');
+        }
+
+        if ($limit) {
+            $qb->setMaxResults($limit);
+        }
+
+        $qb->orderBy('j.added', 'DESC');
+
+        return $qb->getQuery();
+    }
+
+    public function setTtl(?int $ttl = null): void
+    {
+        $this->ttl = $ttl;
+    }
+
+    public function setShouldClearLogForCompleteJob(bool $shouldClearLogForCompleteJob): void
+    {
+        $this->shouldClearLogForCompleteJob = $shouldClearLogForCompleteJob;
+    }
+
+    private function getEntityRepository(): EntityRepository
+    {
+        $repository = $this->doctrine->getRepository(JobLog::class);
+
+        if ($repository instanceof EntityRepository) {
+            return $repository;
+        }
+
+        throw new \RuntimeException(sprintf('Doctrine returned an invalid repository for entity JobLog'));
+    }
+
+    private function getEntityManager(): EntityManager
+    {
+        $manager = $this->doctrine->getManager();
+        if ($manager instanceof EntityManager) {
+            return $manager;
+        }
+
+        throw new \RuntimeException(sprintf('Doctrine returned an invalid type for entity manager'));
+    }
+
+    public function findJobLog(string $uuid): ?JobLog
+    {
+        $jobLog = $this->getEntityRepository()->findOneBy(['uuid' => $uuid]);
+        if ($jobLog instanceof JobLog) {
+            return $jobLog;
+        }
+
+        return null;
+    }
+
+    public function deleteJob(JobLog $jobLog): void
+    {
+        $em = $this->getEntityManager();
+        $em->remove($jobLog);
+        $em->flush($jobLog);
+    }
+
+    public function add(JobLog $jobLog): void
+    {
+        $em = $this->getEntityManager();
+        $em->persist($jobLog);
+        $em->flush($jobLog);
+    }
+
+    public function update(JobLog $jobLog): void
+    {
+        $em = $this->getEntityManager();
+        $em->flush($jobLog);
     }
 
     /**
      * Removes all jobs older than ($this->ttl - 86400 seconds) from all secondary indexes
      */
-    public function removeExpiredJobsFromSecondaryIndexes()
+    public function removeExpiredJobs(): void
     {
-        $interval = new \DateInterval(sprintf('PT%sS', $this->ttl-86400));
+        $interval = new \DateInterval(sprintf('PT%sS', $this->ttl - 86400));
         $before = (new \DateTime('now'))->sub($interval)->format('U');
 
-        // get all old jobs
-        $expiredJobs = $this->predis->zrevrangebyscore($this->getJobAddedKey(), $before, '-inf');
-        if (!$expiredJobs) {
-            return;
-        }
-        foreach($expiredJobs as $jobLogKey) {
-            $this->removeJobFromTimeAddedIndex($jobLogKey);
-            $this->removeJobFromCommandKeyIndexes($jobLogKey);
-            $this->removeJobFromStatusIndexes($jobLogKey);
-        }
-    }
+        $qb = $this->getEntityManager()->createQueryBuilder();
+        $qb->delete(JobLog::class, 'j')
+            ->where($qb->expr()->lte('j.added', ':before'))
+            ->setParameter(':before', $before);
 
-    /**
-     * Save the fact that a job failed
-     *
-     * @param        $uuid
-     * @param string $output
-     * @param string $exitCode
-     */
-    public function saveFailure($uuid, $output = '', $exitCode = null)
-    {
-        try {
-            $log = $this->getJobLog($uuid);
-            $log->setStatus(JobLog::STATUS_FAILED);
-            if (!$log->getCompleted()) {
-                $log->setCompleted((new \DateTime('now'))->format('U'));
-            }
-            $log->setOutput($output);
-            if ($exitCode) {
-                $log->setExitCode($exitCode);
-            }
-            $this->save($log);
-        } catch (UnknownJobLogException $e){
-            // forgive exceptions
-        }
-
-    }
-
-    /**
-     * Save the output from a job
-     *
-     * @param        $uuid
-     */
-    public function saveOutput($uuid, $output = '')
-    {
-      try {
-          $log = $this->getJobLog($uuid);
-          $log->setOutput($output);
-          $this->save($log);
-      } catch (UnknownJobLogException $e){
-          // forgive exceptions
-      }
-    }
-
-
-    /**
-     * Gets a key to identity this job uniquely in redis
-     *
-     * @param $uuid string job Log UUID
-     * @return string
-     */
-    private function getJobLogKey($uuid)
-    {
-       return sprintf('%s:job:%s', self::REDIS_NAMESPACE, $uuid);
-    }
-
-    /**
-     * Gets a temporary key used to construct a temporary intersection/union for a later search
-     *
-     * @param $uuid string job Log UUID
-     * @return string
-     */
-    private function getTempKey()
-    {
-        if ($this->tempKey) {
-            return $this->tempKey;
-        }
-        $tmp = sprintf('%s:temp_key_%', self::REDIS_NAMESPACE, (new \DateTime('now'))->format('U'));
-        $this->tempKey = $tmp;
-        return $tmp;
-    }
-
-    /**
-     * Gets a key for use in the `command` index
-     *
-     * @param $command
-     */
-    private function getCommandKey($command)
-    {
-        $commandHash = hash('SHA256', $command);
-        return sprintf('%s:command:%s', self::REDIS_NAMESPACE, $commandHash);
-    }
-
-    /**
-     * Gets a key for use in the `status` index
-     *
-     * @param $command
-     */
-    private function getStatusKey($status)
-    {
-        return sprintf('%s:status:%s', self::REDIS_NAMESPACE, $status);
-    }
-
-    /**
-     * Gets a key for use in the `added` index
-     *
-     * @param $command
-     */
-    private function getJobAddedKey()
-    {
-        return sprintf('%s:job_added', self::REDIS_NAMESPACE);
-    }
-
-    /**
-     * @param $id
-     * @return JobLog
-     */
-    public function getJobLog($uuid)
-    {
-        return $this->getJobLogByKey($this->getJobLogKey($uuid));
-    }
-
-    /**
-     * @param $id
-     * @return boolean
-     */
-    public function hasJobLog($uuid)
-    {
-        try {
-            $this->getJobLogByKey($this->getJobLogKey($uuid));
-            return true;
-        } catch(UnknownJobLogException $e) {
-            return false;
-        }
-    }
-
-    /**
-     * @param $key string
-     * @throws UnknownJobLogException
-     * @returns JobLog
-     */
-    private function getJobLogByKey($key)
-    {
-        $result = $this->predis->hgetall($key);
-        if (!$result) {
-            throw new UnknownJobLogException(sprintf('Job with key: `%s` cannot be found', $key));
-        }
-        return JobLog::fromCompressedArray($result);
-    }
-
-    /**
-     * Gets JobLog entries discriminated using various options, can also return counts only for use in pagination
-     *
-     * @param SearchJobLogsData $options
-     * @param int               $quantity
-     * @param bool              $countOnly
-     *
-     * @return JobLogCollection | int
-     */
-    public function getJobLogs(
-        SearchJobLogsData $options,
-        $quantity = 10,
-        $countOnly = false
-    ) {
-
-        $since = $options->getSince() ? $options->getSince()->format('U') : '-inf';
-        $before = $options->getBefore() ?$options->getBefore()->format('U') : '+inf';
-
-        if ($options->isDiscriminatorSearch()) {
-            // because searching two indexes - need to make a temporary intersection of both
-            $discriminator = $options->getStatus() ? $this->getStatusKey($options->getStatus()) : $this->getCommandKey($options->getCommand());
-            $this->predis->zinterstore($this->getTempKey(), [$discriminator, $this->getJobAddedKey()], ['AGGREGATE MAX']);
-        }
-
-        if ($countOnly) {
-            if ($options->isIdSearch()) {
-                $result = $this->hasJobLog($options->getId()) ? 1 : 0;
-            } else if ($options->isDiscriminatorSearch()) {
-                $result = $this->predis->zcount($this->getTempKey(), $since, '+inf');
-            } else {
-                $result = $this->predis->zcount($this->getJobAddedKey(), $since, $before);
-            }
-        } else {
-            $result = new JobLogCollection();
-            $rangeOptions['limit'] = [
-                'offset' => $options->getPageOffset() == 0 ? 0 : $options->getPageOffset()*intval($quantity),
-                'count' => intval($quantity)
-            ];
-            $matchingJobs = null;
-
-            if ($options->isIdSearch()) {
-                if ($this->hasJobLog($options->getId())) {
-                    $matchingJobs = [$this->getJobLogKey($options->getId())];
-                }
-            } else if ($options->isDiscriminatorSearch()) {
-                $matchingJobs = $this->predis->zrevrangebyscore($this->getTempKey(), $before, $since, $rangeOptions);
-            } else {
-                $matchingJobs = $this->predis->zrevrangebyscore($this->getJobAddedKey(), $before, $since, $rangeOptions);
-            }
-
-            if ($matchingJobs) {
-                // Iterate the matches and fetch them individually
-                foreach($matchingJobs as $jobLogKey) {
-                    try {
-                        $result->add($this->getJobLogByKey($jobLogKey));
-                    } catch (UnknownJobLogException $e) {
-                        continue;
-                    }
-                }
-            }
-        }
-
-        //unset the temporary key if it exists
-        if ($this->tempKey) {
-            $this->predis->del($this->getTempKey());
-        }
-
-        return $result;
-    }
-
-    /**
-     * @param int $ttl
-     */
-    public function setTtl($ttl = null)
-    {
-        $this->ttl = $ttl;
-
-        return $this;
-    }
-
-    /**
-     * @param bool $shouldClearLogForCompleteJob
-     */
-    public function setShouldClearLogForCompleteJob($shouldClearLogForCompleteJob)
-    {
-        $this->shouldClearLogForCompleteJob = $shouldClearLogForCompleteJob;
-
-        return $this;
+        $qb->getQuery()->execute();
     }
 }

--- a/Resources/config/commands.yml
+++ b/Resources/config/commands.yml
@@ -1,6 +1,8 @@
 services:
     markup_job_queue.command.add_command_job_to_queue:
         class: Markup\JobQueueBundle\Command\AddCommandJobToQueueCommand
+        arguments:
+            - '@jobby'
         tags:
             - { name: console.command, command: 'markup:job_queue:add:command' }
     markup_job_queue.command.add_recurring_console_job_to_queue:

--- a/Resources/config/doctrine/JobLog.orm.yml
+++ b/Resources/config/doctrine/JobLog.orm.yml
@@ -1,0 +1,36 @@
+Markup\JobQueueBundle\Entity\JobLog:
+  type: entity
+  table: job_log
+  id:
+    uuid:
+      type: string
+      unique: true
+      length: 100
+  fields:
+    command:
+      type: text
+    topic:
+      type: string
+      length: 60
+    added:
+      type: datetime
+    started:
+      type: datetime
+      nullable: true
+    completed:
+      type: datetime
+      nullable: true
+    status:
+      type: string
+      length: 60
+    output:
+      type: text
+      nullable: true
+    peakMemoryUse:
+      type: integer
+      length: 255
+      nullable: true
+    exitCode:
+      type: string
+      length: 60
+      nullable: true

--- a/Resources/config/doctrine/JobLog.orm.yml
+++ b/Resources/config/doctrine/JobLog.orm.yml
@@ -3,9 +3,8 @@ Markup\JobQueueBundle\Entity\JobLog:
   table: job_log
   id:
     uuid:
-      type: string
+      type: guid
       unique: true
-      length: 100
   fields:
     command:
       type: text
@@ -31,6 +30,5 @@ Markup\JobQueueBundle\Entity\JobLog:
       length: 255
       nullable: true
     exitCode:
-      type: string
-      length: 60
+      type: integer
       nullable: true

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -51,8 +51,7 @@ services:
     markup_job_queue.repository.job_log:
         class: Markup\JobQueueBundle\Repository\JobLogRepository
         arguments:
-            - '@snc_redis.default'
-            - '@markup_job_queue.reader.recurring_console_command'
+            - '@doctrine'
     markup_job_queue.repository.cron_health:
         class: Markup\JobQueueBundle\Repository\CronHealthRepository
         arguments:

--- a/Service/SupervisordConfigFileWriter.php
+++ b/Service/SupervisordConfigFileWriter.php
@@ -40,6 +40,13 @@ class SupervisordConfigFileWriter
      */
     private $logsDir;
 
+    private $configFilePath;
+
+    /**
+     * @var string
+     */
+    private $mode;
+
     /**
      * SupervisordConfigFileWriter constructor.
      *
@@ -74,7 +81,7 @@ class SupervisordConfigFileWriter
     public function setMode($mode)
     {
         if (!in_array($mode, [self::MODE_PHP, self::MODE_CLI])) {
-            throw new \Exception(sprintf('Mode `%s` is invalid'));
+            throw new \Exception(sprintf('Mode `%s` is invalid', $mode));
         }
         $this->mode = $mode;
     }

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "php-amqplib/rabbitmq-bundle": "^1.8",
         "snc/redis-bundle": "~1.1.2|^2",
         "markup/rabbitmq-management-api": ">=2.1.1",
-        "pagerfanta/pagerfanta": "~1.0.1",
+        "pagerfanta/pagerfanta": "~1.0.2",
         "ramsey/uuid": "^3.8"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "doctrine/collections": "^1.2",
         "php-amqplib/rabbitmq-bundle": "^1.8",
         "snc/redis-bundle": "~1.1.2|^2",
-        "markup/rabbitmq-management-api": ">=2.1.1"
+        "markup/rabbitmq-management-api": ">=2.1.1",
+        "pagerfanta/pagerfanta": "~1.0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.2",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "symfony/framework-bundle": "^3",
         "symfony/finder": "^3",
         "symfony/yaml": "^3",
-        "symfony/console": "^3",
+        "symfony/console": "^3, >3.3",
         "symfony/process": "^3",
         "twig/twig": "^1.12|^2",
         "php": ">=7.1.0",
@@ -28,13 +28,15 @@
         "php-amqplib/rabbitmq-bundle": "^1.8",
         "snc/redis-bundle": "~1.1.2|^2",
         "markup/rabbitmq-management-api": ">=2.1.1",
-        "pagerfanta/pagerfanta": "~1.0.1"
+        "pagerfanta/pagerfanta": "~1.0.1",
+        "ramsey/uuid": "^3.8"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.2",
         "mockery/mockery": "^1.2",
         "symfony/form": "^3",
-        "predis/predis": "^1.0"
+        "predis/predis": "^1.0",
+        "phpstan/phpstan-shim": "^0.11.8"
     },
     "suggest": {
         "ricbra/rabbitmq-cli-consumer": "To consume jobs with Go instead of PHP"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,6 @@
+parameters:
+    excludes_analyse:
+        - %currentWorkingDirectory%/DependencyInjection/Configuration.php
+        - %currentWorkingDirectory%/Tests/*
+        - %currentWorkingDirectory%/vendor/*
+        - %currentWorkingDirectory%/bin/*


### PR DESCRIPTION
1. Changed JobLog repository to use doctrine. 
2. Added some PHP 7.1 types
3. Improved output message on failure
4. Added Pagerfanta usage for pagination purposes

Functionally tested on dev. It requires only migrations from clients to upgrade. 

https://github.com/usemarkup/JobQueueBundle/issues/38