### PR TITLE
feat: set Supervisord startsecs to zero to disable

### DIFF
--- a/Service/SupervisordConfigFileWriter.php
+++ b/Service/SupervisordConfigFileWriter.php
@@ -205,6 +205,7 @@ class SupervisordConfigFileWriter
             $conf[] = "autostart=false";
             $conf[] = "autorestart=true";
             $conf[] = "stopsignal=QUIT";
+            $conf[] = "startsecs=0";
         }
         $conf[] = "\n";
         $conf[] = sprintf("[group:markup_%s]\nprograms=%s", $uniqueEnvironment, implode(',', $programNames));

--- a/Service/SupervisordConfigFileWriter.php
+++ b/Service/SupervisordConfigFileWriter.php
@@ -163,6 +163,7 @@ class SupervisordConfigFileWriter
             $conf[] = "autostart=false";
             $conf[] = "autorestart=true";
             $conf[] = "stopsignal=QUIT";
+            $conf[] = "startsecs=0";
         }
         $conf[] = "\n";
         $conf[] = sprintf("[group:markup_%s]\nprograms=%s", $uniqueEnvironment, implode(',', $programNames));

--- a/Tests/Service/fixtures/supervisord_config_cli.conf
+++ b/Tests/Service/fixtures/supervisord_config_cli.conf
@@ -7,6 +7,7 @@ stdout_logfile=/vagrant/app/logs/supervisord.out.log
 autostart=false
 autorestart=true
 stopsignal=QUIT
+startsecs=0
 
 
 [program:markup_job_queue_testenv_testqueueb]
@@ -16,6 +17,7 @@ stdout_logfile=/vagrant/app/logs/supervisord.out.log
 autostart=false
 autorestart=true
 stopsignal=QUIT
+startsecs=0
 
 
 [group:markup_testenv]

--- a/Tests/Service/fixtures/supervisord_config_php.conf
+++ b/Tests/Service/fixtures/supervisord_config_php.conf
@@ -8,6 +8,7 @@ stdout_logfile=/vagrant/app/logs/supervisord.out.log
 autostart=false
 autorestart=true
 stopsignal=QUIT
+startsecs=0
 
 
 [program:markup_job_queue_testenv_testqueueb]
@@ -18,6 +19,7 @@ stdout_logfile=/vagrant/app/logs/supervisord.out.log
 autostart=false
 autorestart=true
 stopsignal=QUIT
+startsecs=0
 
 
 [group:markup_testenv]


### PR DESCRIPTION
As per http://supervisord.org/configuration.html this will disable default configuration (which hasnt proven to be useful when running very fast commands)

> The total number of seconds which the program needs to stay running after a startup to consider the start successful (moving the process from the STARTING state to the RUNNING state). Set to 0 to indicate that the program needn’t stay running for any particular amount of time.