### PR TITLE
feat: change default idle timeout so follows same as timeout

### DIFF
--- a/Publisher/JobPublisher.php
+++ b/Publisher/JobPublisher.php
@@ -10,6 +10,7 @@ use Markup\JobQueueBundle\Model\Job;
 use Markup\JobQueueBundle\Repository\JobLogRepository;
 use PhpAmqpLib\Exception\AMQPRuntimeException;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -34,16 +35,12 @@ class JobPublisher implements ContainerAwareInterface
      */
     private $logger;
 
-    /**
-     * @param JobLogRepository $jobLogRepository
-     * @param LoggerInterface $logger
-     */
     public function __construct(
         JobLogRepository $jobLogRepository,
-        LoggerInterface $logger
+        LoggerInterface $logger = null
     ) {
         $this->jobLogRepository = $jobLogRepository;
-        $this->logger = $logger;
+        $this->logger = $logger ?? new NullLogger();
     }
 
     /**

--- a/Service/JobManager.php
+++ b/Service/JobManager.php
@@ -43,46 +43,44 @@ class JobManager
         } else {
             $this->scheduledJob->addScheduledJob($job, $dateTime);
         }
-
-        return;
     }
 
     /**
      * Adds a named command to the job queue
-     * @param string  $command     A valid command for this application
-     * @param string  $topic       The name of a valid topic
-     * @param integer $timeout     The amount of time to allow the command to run
-     * @param integer $idleTimeout The amount of idle time to allow the command to run
+     * @param string  $command     A valid command for this application.
+     * @param string  $topic       The name of a valid topic.
+     * @param integer $timeout     The amount of time to allow the command to run.
+     * @param integer $idleTimeout The amount of idle time to allow the command to run. Defaults to the same as timeout.
      */
-    public function addCommandJob($command, $topic = 'default', $timeout = 60, $idleTimeout = 60)
+    public function addCommandJob($command, $topic = 'default', $timeout = 60, $idleTimeout = null)
     {
         $args = [];
         $args['command'] = $command;
         $args['timeout'] = $timeout;
-        $args['idleTimeout'] = $idleTimeout;
+        $args['idleTimeout'] = $idleTimeout ?? $timeout;
         $job = new ConsoleCommandJob($args, $topic);
         $this->addJob($job);
     }
 
     /**
      * Adds a named command to the job queue at a specific datetime
-     * @param string  $command     A valid command for this application
-     * @param string  $dateTime    The DateTime to execute the command
-     * @param string  $topic       The name of a valid topic
-     * @param integer $timeout     The amount of time to allow the command to run
-     * @param integer $idleTimeout The amount of idle time to allow the command to run
+     * @param string  $command     A valid command for this application.
+     * @param string  $dateTime    The DateTime to execute the command.
+     * @param string  $topic       The name of a valid topic.
+     * @param integer $timeout     The amount of time to allow the command to run.
+     * @param integer $idleTimeout The amount of idle time to allow the command to run. Default to the same as timeout.
      */
     public function addScheduledCommandJob(
         $command,
         \DateTime $dateTime,
         $topic = 'default',
         $timeout = 60,
-        $idleTimeout = 60
+        $idleTimeout = null
     ) {
         $args = [];
         $args['command'] = $command;
         $args['timeout'] = $timeout;
-        $args['idleTimeout'] = $idleTimeout;
+        $args['idleTimeout'] = $idleTimeout ?? $timeout;
         $job = new ConsoleCommandJob($args, $topic);
         $this->addJob($job, $dateTime);
     }

--- a/Service/RecurringConsoleCommandReader.php
+++ b/Service/RecurringConsoleCommandReader.php
@@ -40,8 +40,6 @@ class RecurringConsoleCommandReader
         $kernelPath
     ) {
         $this->kernelPath = $kernelPath;
-        $this->configurationFileName = null;
-        $this->configurations = null;
     }
 
     public function setConfigurationFileName($name)

--- a/Tests/Service/JobManagerTest.php
+++ b/Tests/Service/JobManagerTest.php
@@ -2,8 +2,11 @@
 
 namespace Markup\Bundle\JobQueueBundle\Tests\Service;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
 use Markup\JobQueueBundle\Job\SleepJob;
+use Markup\JobQueueBundle\Model\Job;
 use Markup\JobQueueBundle\Publisher\JobPublisher;
+use Markup\JobQueueBundle\Repository\JobLogRepository;
 use Markup\JobQueueBundle\Service\JobManager;
 use Markup\JobQueueBundle\Service\ScheduledJobService;
 use Mockery as m;
@@ -12,41 +15,111 @@ use PHPUnit\Framework\Error\Error;
 
 class JobManagerTest extends MockeryTestCase
 {
+    /**
+     * @var JobPublisher
+     */
+    private $jobPublisher;
+
+    /**
+     * @var ScheduledJobService
+     */
+    private $scheduledJobService;
+
+    /**
+     * @var JobManager
+     */
+    private $jobManager;
+
     protected function setUp()
     {
-        $jobPublisher = m::mock(JobPublisher::class);
-        $scheduledJob = m::mock(ScheduledJobService::class);
-        $jobPublisher->shouldReceive('publish')->andReturn(null);
-        $scheduledJob->shouldReceive('addScheduledJob')->andReturn(null);
-        $this->jobManager = new JobManager($jobPublisher, $scheduledJob);
+        $this->jobPublisher = $this->createStoringJobPublisher();
+        $this->scheduledJobService = $this->createStoringJobScheduler();
+        $this->jobManager = new JobManager(
+            $this->jobPublisher,
+            $this->scheduledJobService
+        );
     }
 
     public function testCanAddJob()
     {
         $job = new SleepJob();
         $scheduledTime = new \DateTime();
-        $this->assertNull($this->jobManager->addJob($job));
-        $this->assertNull($this->jobManager->addJob($job, $scheduledTime));
-    }
-
-    public function testDoesNotAcceptBadJobs()
-    {
-        $badjob = 'console:herp:derp';
-        $exceptionThrown = false;
-        try {
-            $this->jobManager->addJob($badjob);
-        } catch (Error $e) {
-            $exceptionThrown = true;
-        } catch (\TypeError $e) {
-            $exceptionThrown = true;
-        }
-        if (!$exceptionThrown) {
-            $this->fail();
-        }
+        $this->jobManager->addJob($job);
+        $this->jobManager->addJob($job, $scheduledTime);
+        $this->assertSame([$job], $this->jobPublisher->getJobs());
+        $this->assertSame([$job], $this->scheduledJobService->getJobs());
     }
 
     public function testCanAddCommandJob()
     {
-        $this->assertNull($this->jobManager->addCommandJob('console:herp:derp', 'system', 60, 60));
+        $this->jobManager->addCommandJob('console:herp:derp', 'system', 60, 60);
+        $this->assertCount(1, $this->jobPublisher->getJobs());
+    }
+
+    public function testIdleTimeoutDefaultsToTimeout()
+    {
+        $timeout = 720;
+        $this->jobManager->addCommandJob('command', 'topic', $timeout);
+        /** @var Job $job */
+        $job = $this->jobPublisher->getJobs()[0];
+        $this->assertEquals($timeout, $job->getArgs()['idleTimeout']);
+    }
+
+    private function createStoringJobPublisher(): JobPublisher
+    {
+        return new class () extends JobPublisher {
+            use JobStore;
+
+            public function __construct()
+            {
+                parent::__construct(m::mock(JobLogRepository::class));
+                $this->initializeJobs();
+            }
+
+            public function publish(Job $job)
+            {
+                $this->addJob($job);
+            }
+        };
+    }
+
+    private function createStoringJobScheduler()
+    {
+        return new class () extends ScheduledJobService {
+            use JobStore;
+
+            public function __construct()
+            {
+                parent::__construct(m::mock(ManagerRegistry::class));
+                $this->initializeJobs();
+            }
+
+            public function addScheduledJob(Job $job, $scheduledTime)
+            {
+                $this->addJob($job);
+            }
+        };
+    }
+}
+
+trait JobStore {
+    /**
+     * @var array<Job>
+     */
+    private $jobs;
+
+    private function initializeJobs(): void
+    {
+        $this->jobs = [];
+    }
+
+    private function addJob(Job $job): void
+    {
+        $this->jobs[] = $job;
+    }
+
+    public function getJobs(): array
+    {
+        return $this->jobs;
     }
 }


### PR DESCRIPTION
This is a better default than having to specify the idle timeout every time, because there don't seem to be cases in the wild where the chosen idle timeout is less than the timeout, making the idle timeout generally pretty redundant. (Furthermore, idle timeout is currently impossible to set in recurring job configurations.)