### PR TITLE
fix: prevent job logging communication issues failing the message

### DIFF
--- a/Consumer/JobConsumer.php
+++ b/Consumer/JobConsumer.php
@@ -41,13 +41,17 @@ class JobConsumer implements ConsumerInterface, ContainerAwareInterface
             $output = $job->run($this->container);
 
             if (isset($data['uuid'])) {
-                $this->getJobLogRepository()->saveOutput(
-                    $data['uuid'],
-                    strval($output)
-                );
+                try {
+                    $this->getJobLogRepository()->saveOutput(
+                        $data['uuid'],
+                        strval($output)
+                    );
+                } catch (\Throwable $t) {
+                    // do nothing
+                }
             }
 
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $command = '';
 
             if ((isset($job))) {
@@ -64,11 +68,15 @@ class JobConsumer implements ConsumerInterface, ContainerAwareInterface
             }
             // save failure if job had uuid
             if (isset($data['uuid'])) {
-                $this->getJobLogRepository()->saveFailure(
-                    $data['uuid'],
-                    strval($output),
-                    $exitCode ?? 1
-                );
+                try {
+                    $this->getJobLogRepository()->saveFailure(
+                        $data['uuid'],
+                        strval($output),
+                        $exitCode ?? 1
+                    );
+                } catch (\Throwable $t) {
+                    // do nothing
+                }
             }
 
             $this->container->get('logger')->error(sprintf('Job Failed: %s', $command), [


### PR DESCRIPTION
In the event of `saveFailure` and `saveOutput` throwing exceptions the whole consumer will exit with a failure code. This simple try/catch prevents that bubbling up as its more important to continue that operation than anything else.

Furthermore, because this is now a Doctrine backed implementation it means if the connection is cut due to an issue with the main execution its wise to expect this to throw exceptions given its current implementation. 