### PR TITLE
refactor: add phpstan level 2 coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   - if [ "$deps" = "low" ]; then composer --prefer-lowest -n --prefer-stable --prefer-dist update; fi;
 
 
-script: bin/phpunit && bin/phpstan analyse -l 1 ./
+script: bin/phpunit && bin/phpstan analyse -l 2 ./
 
 notifications:
   email: "calum@usemarkup.com"

--- a/Command/ReadRecurringConsoleJobConfigurationCommand.php
+++ b/Command/ReadRecurringConsoleJobConfigurationCommand.php
@@ -70,8 +70,8 @@ class ReadRecurringConsoleJobConfigurationCommand extends ContainerAwareCommand
 
     /**
      * Uses the process component to determine if a command is valid, by looking at the output of cmd:xyz --help
-     * @param  $command
-     * @return boolean
+     * @param  string $command
+     * @return bool
      */
     private function isCommandValid($command)
     {

--- a/Model/Queue.php
+++ b/Model/Queue.php
@@ -46,18 +46,6 @@ class Queue
      */
     private $idleSince;
 
-    /**
-     * Queue constructor.
-     *
-     * @param          $name
-     * @param          $vhost
-     * @param          $state
-     * @param          $consumerCount
-     * @param          $messages
-     * @param          $messagesReady
-     * @param          $messagesUnacknowledged
-     * @param \DateTime $idleSince
-     */
     public function __construct(
         $name,
         $vhost,
@@ -81,12 +69,11 @@ class Queue
     /**
      * Takes the response from the RabbitMq Api for queues and uses it to build an instance of this class
      *
-     * @param $response string
+     * @param  array $response
      * @return Queue
      */
     public static function constructFromApiResponse(array $response)
     {
-
         return new self(
             isset($response['name']) ? $response['name'] : 'undefined',
             isset($response['vhost']) ? $response['vhost'] : 'undefined',

--- a/Model/ScheduledJobRepositoryInterface.php
+++ b/Model/ScheduledJobRepositoryInterface.php
@@ -6,7 +6,6 @@ use Markup\JobQueueBundle\Entity\ScheduledJob;
 
 interface ScheduledJobRepositoryInterface
 {
-
     /**
      * @return mixed
      */

--- a/Service/CliConsumerConfigFileWriter.php
+++ b/Service/CliConsumerConfigFileWriter.php
@@ -52,15 +52,6 @@ class CliConsumerConfigFileWriter
      */
     private $topics;
 
-    /**
-     * @param $logPath
-     * @param $configFilePath
-     * @param $host
-     * @param $username
-     * @param $password
-     * @param $vhost
-     * @param $port
-     */
     public function __construct(
         $logPath,
         $configFilePath,
@@ -117,9 +108,9 @@ class CliConsumerConfigFileWriter
     }
 
     /**
-     * @param $uniqueEnvironment
-     * @param $topic
-     * @param $topicConfig
+     * @param string $uniqueEnvironment
+     * @param string $topic
+     * @param array $topicConfig
      * @return string
      */
     public function getConfigString($uniqueEnvironment, $topic, $topicConfig)

--- a/Service/JobManager.php
+++ b/Service/JobManager.php
@@ -5,7 +5,6 @@ namespace Markup\JobQueueBundle\Service;
 use Markup\JobQueueBundle\Job\ConsoleCommandJob;
 use Markup\JobQueueBundle\Model\Job;
 use Markup\JobQueueBundle\Publisher\JobPublisher;
-use Symfony\Bundle\FrameworkBundle\Console\Application;
 
 /**
  * Controller for adding jobs to a queue
@@ -13,7 +12,6 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
  */
 class JobManager
 {
-
     /**
      * @var JobPublisher
      */
@@ -40,7 +38,7 @@ class JobManager
     {
         if ($dateTime === null) {
             $this->publisher->publish($job);
-        } else {
+        } elseif ($job instanceof ConsoleCommandJob) {
             $this->scheduledJob->addScheduledJob($job, $dateTime);
         }
     }
@@ -64,11 +62,11 @@ class JobManager
 
     /**
      * Adds a named command to the job queue at a specific datetime
-     * @param string  $command     A valid command for this application.
-     * @param string  $dateTime    The DateTime to execute the command.
-     * @param string  $topic       The name of a valid topic.
-     * @param integer $timeout     The amount of time to allow the command to run.
-     * @param integer $idleTimeout The amount of idle time to allow the command to run. Default to the same as timeout.
+     * @param string    $command     A valid command for this application.
+     * @param \DateTime $dateTime    The DateTime to execute the command.
+     * @param string    $topic       The name of a valid topic.
+     * @param int       $timeout     The amount of time to allow the command to run.
+     * @param int       $idleTimeout The amount of idle time to allow the command to run. Default to the same as timeout.
      */
     public function addScheduledCommandJob(
         $command,

--- a/Service/RecurringConsoleCommandReader.php
+++ b/Service/RecurringConsoleCommandReader.php
@@ -34,7 +34,7 @@ class RecurringConsoleCommandReader
     private $configurations;
 
     /**
-     * @param $kernelPath string
+     * @param string $kernelPath
      */
     public function __construct(
         $kernelPath
@@ -69,7 +69,7 @@ class RecurringConsoleCommandReader
     }
 
     /**
-     * @param $uuid
+     * @param string $id
      */
     public function getConfigurationById($id)
     {
@@ -115,7 +115,7 @@ class RecurringConsoleCommandReader
      * Parses the configuration and returns an array of of configuration objects
      * Configuration is cached after running this function so it should only be run once
      *
-     * @param ArrayCollection<RecurringConsoleCommandConfiguration>
+     * @return ArrayCollection<RecurringConsoleCommandConfiguration>
      */
     private function parseConfiguration(array $config)
     {

--- a/Service/ScheduledJobService.php
+++ b/Service/ScheduledJobService.php
@@ -3,10 +3,9 @@
 namespace Markup\JobQueueBundle\Service;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
-use Doctrine\Common\Persistence\ObjectRepository;
-use Markup\JobQueueBundle\Entity\Repository\ScheduledJobRepository;
 use Markup\JobQueueBundle\Entity\ScheduledJob;
-use Markup\JobQueueBundle\Model\Job;
+use Markup\JobQueueBundle\Job\ConsoleCommandJob;
+use Markup\JobQueueBundle\Model\ScheduledJobRepositoryInterface;
 
 class ScheduledJobService
 {
@@ -25,11 +24,11 @@ class ScheduledJobService
     }
 
     /**
-     * @param Job $job
-     * @param \DateTime $scheduledTime
+     * @param ConsoleCommandJob $job
+     * @param \DateTime|string $scheduledTime
      * @return ScheduledJob
      */
-    public function addScheduledJob(Job $job, $scheduledTime)
+    public function addScheduledJob(ConsoleCommandJob $job, $scheduledTime)
     {
         $scheduledJob = new ScheduledJob($job->getCommand(), $scheduledTime, $job->getTopic());
         $this->save($scheduledJob, true);
@@ -57,11 +56,11 @@ class ScheduledJobService
         return $this->getScheduledJobRepository()->fetchUnqueuedJobs();
     }
 
-    /**
-     * @return ObjectRepository|ScheduledJobRepository
-     */
-    private function getScheduledJobRepository()
+    private function getScheduledJobRepository(): ScheduledJobRepositoryInterface
     {
-        return $this->managerRegistry->getRepository(ScheduledJob::class);
+        /** @var ScheduledJobRepositoryInterface $repository */
+        $repository = $this->managerRegistry->getRepository(ScheduledJob::class);
+
+        return $repository;
     }
 }

--- a/Service/SupervisordConfigFileWriter.php
+++ b/Service/SupervisordConfigFileWriter.php
@@ -47,16 +47,6 @@ class SupervisordConfigFileWriter
      */
     private $mode;
 
-    /**
-     * SupervisordConfigFileWriter constructor.
-     *
-     * @param $kernelPath
-     * @param $logsDir
-     * @param $kernelEnv
-     * @param $supervisordConfigPath
-     * @param $consumerPath
-     * @param $configFilePath
-     */
     public function __construct(
         $kernelPath,
         $logsDir,
@@ -118,7 +108,7 @@ class SupervisordConfigFileWriter
     }
 
     /**
-     * @param $uniqueEnvironment string environment disambiguator
+     * @param string $uniqueEnvironment  environment disambiguator
      * @param bool $skipExistsChecks If set skips FS checks for binary and config file
      * @return string
      */
@@ -179,7 +169,7 @@ class SupervisordConfigFileWriter
     }
 
     /**
-     * @param $uniqueEnvironment
+     * @param string $uniqueEnvironment
      * @return string
      */
     public function getConfigForPhpConsumer($uniqueEnvironment, $skipExistsChecks = false)

--- a/Tests/Service/JobManagerTest.php
+++ b/Tests/Service/JobManagerTest.php
@@ -3,6 +3,8 @@
 namespace Markup\Bundle\JobQueueBundle\Tests\Service;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
+use Markup\JobQueueBundle\Entity\ScheduledJob;
+use Markup\JobQueueBundle\Job\ConsoleCommandJob;
 use Markup\JobQueueBundle\Job\SleepJob;
 use Markup\JobQueueBundle\Model\Job;
 use Markup\JobQueueBundle\Publisher\JobPublisher;
@@ -40,23 +42,28 @@ class JobManagerTest extends MockeryTestCase
         );
     }
 
-    public function testCanAddJob()
+    public function testCanAddJobWithoutDateTime(): void
     {
         $job = new SleepJob();
-        $scheduledTime = new \DateTime();
         $this->jobManager->addJob($job);
-        $this->jobManager->addJob($job, $scheduledTime);
         $this->assertSame([$job], $this->jobPublisher->getJobs());
+    }
+
+    public function testCanAddConsoleCommandJobWithDateTime(): void
+    {
+        $job = new ConsoleCommandJob();
+        $scheduledTime = new \DateTime();
+        $this->jobManager->addJob($job, $scheduledTime);
         $this->assertSame([$job], $this->scheduledJobService->getJobs());
     }
 
-    public function testCanAddCommandJob()
+    public function testCanAddCommandJob(): void
     {
         $this->jobManager->addCommandJob('console:herp:derp', 'system', 60, 60);
         $this->assertCount(1, $this->jobPublisher->getJobs());
     }
 
-    public function testIdleTimeoutDefaultsToTimeout()
+    public function testIdleTimeoutDefaultsToTimeout(): void
     {
         $timeout = 720;
         $this->jobManager->addCommandJob('command', 'topic', $timeout);
@@ -94,7 +101,7 @@ class JobManagerTest extends MockeryTestCase
                 $this->initializeJobs();
             }
 
-            public function addScheduledJob(Job $job, $scheduledTime)
+            public function addScheduledJob(ConsoleCommandJob $job, $scheduledTime)
             {
                 $this->addJob($job);
             }

--- a/Util/LegacyFormHelper.php
+++ b/Util/LegacyFormHelper.php
@@ -16,7 +16,7 @@ final class LegacyFormHelper
     ];
 
     /**
-     * @param $class
+     * @param string $class
      *
      * @return mixed
      */


### PR DESCRIPTION
Having Level 2 coverage means we can automatically check for methods existing on an object, which is useful for testing for Symfony upgrades.

NB. There is a change of typing for some methods because scheduled jobs can only be ConsoleCommandJob instances otherwise adding them will fail as there is no base `getCommand()` method.