### PR TITLE
build: allow symfony 3 or 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,11 @@
     ],
     "require": {
         "php": ">=7.1",
-        "symfony/framework-bundle": "^3.4",
-        "symfony/finder": "^3.4",
-        "symfony/yaml": "^3.4",
-        "symfony/console": "^3.4",
-        "symfony/process": "^3.4",
+        "symfony/framework-bundle": "^3.4|^4",
+        "symfony/finder": "^3.4|^4",
+        "symfony/yaml": "^3.4|^4",
+        "symfony/console": "^3.4|^4",
+        "symfony/process": "^3.4|^4",
         "twig/twig": "^2",
         "mtdowling/cron-expression": "1.0.*",
         "doctrine/orm": "~2.7",
@@ -34,7 +34,7 @@
     "require-dev": {
         "phpunit/phpunit": "^7.2",
         "mockery/mockery": "^1.2",
-        "symfony/form": "^3.4",
+        "symfony/form": "^3.4|^4",
         "predis/predis": "^1.0",
         "phpstan/phpstan-shim": "^0.11.8"
     },


### PR DESCRIPTION
No actual changes here, just allowing the dependencies to be installed upstream