### PR TITLE
fix: add native argument support for recurring jobs

### DIFF
--- a/Model/RecurringConsoleCommandConfiguration.php
+++ b/Model/RecurringConsoleCommandConfiguration.php
@@ -41,16 +41,23 @@ class RecurringConsoleCommandConfiguration
     private $envs;
 
     /**
-     * @param string  $command
-     * @param string  $topic
-     * @param string  $schedule
-     * @param string|null  $description
+     * @var array
+     */
+    private $arguments;
+
+    /**
+     * @param string $command
+     * @param array $arguments
+     * @param string $topic
+     * @param string $schedule
+     * @param string|null $description
      * @param integer|null $timeout
      * @param array|null $envs
      */
-    public function __construct($command, $topic, $schedule, $description = null, $timeout = 60, $envs = null)
+    public function __construct($command, array $arguments, $topic, $schedule, $description = null, $timeout = 60, $envs = null)
     {
         $this->command = $command;
+        $this->arguments = $arguments;
         $this->schedule = $schedule;
         $this->topic = str_replace('-', '_', $topic);
         $this->timeout = $timeout;
@@ -74,6 +81,14 @@ class RecurringConsoleCommandConfiguration
     public function getCommand()
     {
         return $this->command;
+    }
+
+    /**
+     * @return array
+     */
+    public function getArguments(): array
+    {
+        return $this->arguments;
     }
 
     /**

--- a/Service/RecurringConsoleCommandReader.php
+++ b/Service/RecurringConsoleCommandReader.php
@@ -129,8 +129,13 @@ class RecurringConsoleCommandReader
                 throw new InvalidConfigurationException('`envs` config key must be an array or null');
             }
 
+            if (isset($group['arguments']) && !is_array($group['arguments'])) {
+                throw new InvalidConfigurationException(sprintf('`arguments` config key must be an array for %s', $group['command']));
+            }
+
             $recurringConsoleCommandConfiguration = new RecurringConsoleCommandConfiguration(
                 $group['command'],
+                $group['arguments'] ?? [],
                 $group['topic'],
                 $group['schedule'],
                 isset($group['description']) ? $group['description'] : null,

--- a/Tests/Model/RecurringConsoleCommandConfigurationTest.php
+++ b/Tests/Model/RecurringConsoleCommandConfigurationTest.php
@@ -9,7 +9,7 @@ class RecurringConsoleCommandConfigurationTest extends TestCase
 {
     public function testCanBeConstructed()
     {
-        $config = new RecurringConsoleCommandConfiguration('foo:bar', 'test', '30 1 * * *', 'a short description');
+        $config = new RecurringConsoleCommandConfiguration('foo:bar', [], 'test', '30 1 * * *', 'a short description');
         $this->assertEquals($config->getCommand(), 'foo:bar');
         $this->assertEquals($config->getTopic(), 'test');
         $this->assertEquals($config->getSchedule(), '30 1 * * *');


### PR DESCRIPTION
An attempt to keep the recurring jobs file as a non-breaking change came with a downside that to 'detect' the arguments were assumed too much.

Inturn this created bugs, seems we are forced to change the definition here in-order to prevent further problems 